### PR TITLE
Fix timeouts for requests routed through Azure CDN when compression enabled at the origin

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,3 @@
 # Set defaults for the production build (i.e. `next dev`) here
-NEXT_COMPRESS="false"
+NEXT_COMPRESS="true"
 NODE_ENV="production"

--- a/infra/cdn/cdn.bicep
+++ b/infra/cdn/cdn.bicep
@@ -3,6 +3,7 @@ param endpointName string
 param location string = resourceGroup().location
 param tags object = {}
 param originHostName string
+param buildId string
 
 var originUri = 'https://${originHostName}'
 
@@ -57,15 +58,15 @@ resource endpoint 'Microsoft.Cdn/profiles/endpoints@2022-11-01-preview' = {
             {
               name: 'RequestHeader'
               parameters: {
-                  operator: length(originUri) > 64 ? 'BeginsWith' : 'Equal'
-                  selector: 'Origin'
-                  negateCondition: false
-                  // A match value longer than 64 characters will cause an error
-                  matchValues: [
-                    length(originUri) > 64 ? take(originUri, 64) : originUri
-                  ]
-                  transforms: []
-                  typeName: 'DeliveryRuleRequestHeaderConditionParameters'
+                operator: length(originUri) > 64 ? 'BeginsWith' : 'Equal'
+                selector: 'Origin'
+                negateCondition: false
+                // A match value longer than 64 characters will cause an error
+                matchValues: [
+                  length(originUri) > 64 ? take(originUri, 64) : originUri
+                ]
+                transforms: []
+                typeName: 'DeliveryRuleRequestHeaderConditionParameters'
               }
             }
           ]
@@ -73,10 +74,10 @@ resource endpoint 'Microsoft.Cdn/profiles/endpoints@2022-11-01-preview' = {
             {
               name: 'ModifyResponseHeader'
               parameters: {
-                  headerAction: 'Overwrite'
-                  headerName: 'Access-Control-Allow-Origin'
-                  value: originUri
-                  typeName: 'DeliveryRuleHeaderActionParameters'
+                headerAction: 'Overwrite'
+                headerName: 'Access-Control-Allow-Origin'
+                value: originUri
+                typeName: 'DeliveryRuleHeaderActionParameters'
               }
             }
           ]
@@ -88,13 +89,13 @@ resource endpoint 'Microsoft.Cdn/profiles/endpoints@2022-11-01-preview' = {
             {
               name: 'UrlPath'
               parameters: {
-                  operator: 'BeginsWith'
-                  negateCondition: false
-                  matchValues: [
-                    '_next/'
-                  ]
-                  transforms: []
-                  typeName: 'DeliveryRuleUrlPathMatchConditionParameters'
+                operator: 'BeginsWith'
+                negateCondition: false
+                matchValues: [
+                  '_next/'
+                ]
+                transforms: []
+                typeName: 'DeliveryRuleUrlPathMatchConditionParameters'
               }
             }
           ]
@@ -102,10 +103,40 @@ resource endpoint 'Microsoft.Cdn/profiles/endpoints@2022-11-01-preview' = {
             {
               name: 'ModifyResponseHeader'
               parameters: {
-                  headerAction: 'Overwrite'
-                  headerName: 'Access-Control-Allow-Origin'
-                  value: originUri
-                  typeName: 'DeliveryRuleHeaderActionParameters'
+                headerAction: 'Overwrite'
+                headerName: 'Access-Control-Allow-Origin'
+                value: originUri
+                typeName: 'DeliveryRuleHeaderActionParameters'
+              }
+            }
+          ]
+        }
+        {
+          name: 'NoCompressAtOrigin'
+          order: 3
+          conditions: [
+            {
+              name: 'UrlPath'
+              parameters: {
+                operator: 'BeginsWith'
+                negateCondition: false
+                matchValues: [
+                  '_next/'
+                  '${buildId}/'
+                ]
+                transforms: []
+                typeName: 'DeliveryRuleUrlPathMatchConditionParameters'
+              }
+            }
+          ]
+          actions: [
+            {
+              name: 'ModifyRequestHeader'
+              parameters: {
+                headerAction: 'Delete'
+                headerName: 'Accept-Encoding'
+                value: null
+                typeName: 'DeliveryRuleHeaderActionParameters'
               }
             }
           ]

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -138,6 +138,8 @@ var webAppServiceHostName = !empty(webAppServiceCustomDomainName) ? webAppServic
 
 var webAppServiceUri = 'https://${webAppServiceHostName}'
 
+var buildId = uniqueString(resourceGroup.id, deployment().name)
+
 module webAppServiceCdn './cdn/cdn.bicep' = {
   name: '${webAppServiceName}-cdn'
   scope: resourceGroup
@@ -147,10 +149,9 @@ module webAppServiceCdn './cdn/cdn.bicep' = {
     location: location
     tags: tags
     originHostName: webAppServiceHostName
+    buildId: buildId
   }
 }
-
-var buildId = uniqueString(resourceGroup.id, deployment().name)
 
 module webAppServiceContainerApp './web-app.bicep' = {
   name: '${webAppServiceName}-container-app'
@@ -176,7 +177,7 @@ module webAppServiceContainerApp './web-app.bicep' = {
       }
       {
         name: 'NEXT_COMPRESS'
-        value: stringOrDefault(envVars.NEXT_COMPRESS, 'false')
+        value: stringOrDefault(envVars.NEXT_COMPRESS, 'true')
       }
       {
         name: 'NEXT_PUBLIC_APP_ENV'

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ const buildId = process.env.NEXT_PUBLIC_BUILD_ID || null
 const customDomainName = process.env.SERVICE_WEB_CUSTOM_DOMAIN_NAME || ''
 
 const remotePatterns = []
+const headers = []
 const rewrites = {}
 const redirects = []
 
@@ -25,6 +26,17 @@ if (buildId) {
       destination: '/:path*'
     }
   ]
+
+  // Also add a cache control header as these resources are immutable for each build
+  headers.push({
+    source: `/${buildId}/:path*`,
+    headers: [
+      {
+        key: 'Cache-Control',
+        value: 'public, max-age=31536000, immutable'
+      }
+    ]
+  })
 }
 
 if (customDomainName) {
@@ -61,6 +73,9 @@ const nextConfig = {
   },
   images: {
     remotePatterns
+  },
+  async headers() {
+    return headers
   },
   async rewrites() {
     return rewrites

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
         "pino-pretty": "^10.2.0",
-        "prettier": "^3.0.3",
+        "prettier": "^3.1.0",
         "typescript": "^5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
     "pino-pretty": "^10.2.0",
-    "prettier": "^3.0.3",
+    "prettier": "^3.1.0",
     "typescript": "^5"
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css'
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import { PreloadResources } from './preload-resources'
 import { AppInsightsProvider } from '@/components/instrumentation/AppInsightsProvider'
 
 const inter = Inter({ subsets: ['latin'] })
@@ -17,6 +18,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
+      <PreloadResources />
       <body className={inter.className}>
         <AppInsightsProvider>{children}</AppInsightsProvider>
       </body>

--- a/src/app/preload-resources.tsx
+++ b/src/app/preload-resources.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import ReactDOM from 'react-dom'
+import { getCdnUrl } from '@/lib/url'
+
+function PreloadResources() {
+  const cdnUrl = getCdnUrl('', false)
+
+  if (cdnUrl.length > 0) {
+    // @ts-ignore
+    ReactDOM.preconnect(cdnUrl)
+  }
+
+  return null
+}
+
+export { PreloadResources }

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -32,12 +32,20 @@ const getAbsoluteUrl = (path?: string) => {
   return joinUrlSegments([baseUrl, path])
 }
 
-const getCdnUrl = (path: string) => {
-  if (!baseCdnUrl || !buildId) {
-    return path
+const getCdnUrl = (path?: string, includeFingerprint = true) => {
+  if (!baseCdnUrl) {
+    return path ?? ''
   }
 
-  return joinUrlSegments([baseCdnUrl, buildId, path])
+  if (!path) {
+    return baseCdnUrl
+  }
+
+  if (includeFingerprint && buildId) {
+    return joinUrlSegments([baseCdnUrl, buildId, path])
+  }
+
+  return joinUrlSegments([baseCdnUrl, path])
 }
 
 export { getAbsoluteUrl, getCdnUrl }


### PR DESCRIPTION
A couple of solutions were tried and considered:

1. Introduce a proxy in front of the Next.js app that can a) deal with the `Range` requests causing the issue; and b) take care of compressing responses so Next.js isn't doing this
   * Next.js [recommend using a proxy](https://nextjs.org/docs/app/api-reference/next-config-js/compress) to compress responses so this is not a bad approach
   * Caddy was deployed as a sidecar to the Next.js container and configured as a reverse proxy and worked as a POC
   * It introduced more complexity though - sidecars don't seem well supported by `azd` and it requires using a storage account as a fileshare for Caddy config and data
   * I also didn't get as far as thinking through impact on local development, dev container/codespaces (if any); or how to deploy the Caddy config as part of the `azd` workflow (perhaps Caddy would need to be a service of its own rather than a sidecar)
   * It started to feel like the scale in complexity didn't fit the scale of the problem
2. Modify the request headers to the origin from the Azure CDN to remove `Accept-Encoding` so as not to "interfere" with the `Range` requests
   * This is a much simpler solution as it basically relies on adding a new rule to the CDN to remove the `Accept-Encoding` header for known paths (static assets and URLs "fingerprinted" with the `buildId`)
   * The idea is that the response from the origin to the CDN will not be compressed so as not to "interfere" with `Range` requests, but the response from the CDN to the client will be compressed by the CDN
   * This still means that `Next.js` is doing some compression, which is maybe not ideal for high traffic production workloads, but there is still an option to introduce a proxy like Caddy if and when that is needed

Solution 2 has been implemented.

Closes #9 